### PR TITLE
Feature teensy4 sd ble

### DIFF
--- a/src/AICSHield.cpp
+++ b/src/AICSHield.cpp
@@ -5,17 +5,17 @@
 
 //Front/Rear is weird.  Left/Right matches the enclosure labeling.
 const int EarpieceShield::PDM_LEFT_FRONT = 1;
-const int EarpieceShield::PDM_LEFT_REAR = 0;    
+const int EarpieceShield::PDM_LEFT_REAR = 0;
 const int EarpieceShield::PDM_RIGHT_FRONT = 3;
 const int EarpieceShield::PDM_RIGHT_REAR = 2;
 
  //left/right for headphone jack on main tympan board
 const int EarpieceShield::OUTPUT_LEFT_TYMPAN = 0;
-const int EarpieceShield::OUTPUT_RIGHT_TYMPAN = 1;  
-		
+const int EarpieceShield::OUTPUT_RIGHT_TYMPAN = 1;
+
 //Left/Right matches the enclosure...but is backwards from ideal
 const int EarpieceShield::OUTPUT_LEFT_EARPIECE = 3;
-const int EarpieceShield::OUTPUT_RIGHT_EARPIECE = 2;  
+const int EarpieceShield::OUTPUT_RIGHT_EARPIECE = 2;
 
 
 void AICShieldBase::setupPins(const AICShieldPins &_pins) {
@@ -27,16 +27,17 @@ void AICShieldBase::setupPins(const AICShieldPins &_pins) {
 	if (pins.CCP_atten1 != NOT_A_FEATURE) { pinMode(pins.CCP_atten1,OUTPUT); digitalWrite(pins.CCP_atten1,LOW); }
 	if (pins.CCP_atten2 != NOT_A_FEATURE) { pinMode(pins.CCP_atten2,OUTPUT); digitalWrite(pins.CCP_atten2,LOW); }
 	if (pins.CCP_bigLED != NOT_A_FEATURE) { pinMode(pins.CCP_bigLED,OUTPUT); digitalWrite(pins.CCP_bigLED,LOW); }
-	if (pins.CCP_littleLED != NOT_A_FEATURE) { pinMode(pins.CCP_littleLED,OUTPUT); digitalWrite(pins.CCP_littleLED,LOW); }
-	
-	
-	
+	if (pins.CCP_littleLED_1 != NOT_A_FEATURE) {
+		pinMode(pins.CCP_littleLED_1,OUTPUT); digitalWrite(pins.CCP_littleLED_1,LOW);
+		pinMode(pins.CCP_littleLED_2,OUTPUT); digitalWrite(pins.CCP_littleLED_2,LOW);
+	}
+
 	//setup the AIC shield pins
 	if (pins.enableStereoExtMicBias != NOT_A_FEATURE) {
 		pinMode(pins.enableStereoExtMicBias,OUTPUT);
 		setEnableStereoExtMicBias(true); //enable stereo external mics (REV_D)
 	}
-	
+
 };
 
 int AICShieldBase::setEnableStereoExtMicBias(int new_state) {
@@ -47,5 +48,3 @@ int AICShieldBase::setEnableStereoExtMicBias(int new_state) {
 		return pins.enableStereoExtMicBias;
 	}
 }
-
-

--- a/src/AICShield.h
+++ b/src/AICShield.h
@@ -25,8 +25,10 @@ enum class AICShieldRev { A, CCP, CCP_A };
 #define NOT_A_FEATURE (-9999)
 #endif
 
-#define AICSHIELD_DEFAULT_RESET_PIN 20
-#define AICSHIELD_DEFAULT_I2C_BUS  2
+#define AICSHIELD_DEFAULT_RESET_PIN 42
+#define AICSHIELD_DEFAULT_I2C_BUS	2
+#define AICSHIELD_VARIANT_I2C_BUS  0
+#define AICSHIELD_I2C_BUS_SET_INTERNAL	4
 
 
 class AICShieldPins {
@@ -41,63 +43,73 @@ class AICShieldPins {
 		void setAICShieldRev(TympanRev _tympanRev, AICShieldRev _AICRev) {
 			tympanRev = _tympanRev;
 			AICRev = _AICRev;
-					
+
 			switch (tympanRev) { //which Tympan are we connecting to?
-				
+
 				case (TympanRev::D) : case (TympanRev::D4) :   //we're connecting to a Rev D tympan, so the pin numbers below are correct for the TympanD
-				
+
 					switch (AICRev) {  //which AIC_shield are we connecting to?
-					
+
 						case (AICShieldRev::A) :    //Basic AIC shield (2019 and 2020)
 							//Teensy 3.6 Pin Numbering
-							resetAIC = 42; //Fixed 2020-06-01
+							resetAIC = AICSHIELD_DEFAULT_RESET_PIN; //Fixed 2020-06-01
 							i2cBus = 2;
-							enableStereoExtMicBias = 41; 
+							enableStereoExtMicBias = 41;
 							defaultInput = AudioControlAIC3206::IN3;  //IN3 is the pink mic/line jack
 							break;
-							
+
 						case (AICShieldRev::CCP):  case (AICShieldRev::CCP_A): //First generation CCP shield (May 2020)
 							//Teensy 3.6 Pin Numbering
-							resetAIC = 42;   //Fixed 2020-06-01
-							i2cBus = 2;
-							enableStereoExtMicBias = 41; 
+							resetAIC = AICSHIELD_DEFAULT_RESET_PIN;   //Fixed 2020-06-01
+							pinMode(7,INPUT_PULLUP); delay(10); int pinValue = digitalRead(7);
+							if(pinValue == 1){	// production Rev D
+								i2cBus = 2;
+							} else {					// prototype Rev D with op amps
+								i2cBus = 0;
+								resetAIC = 35;
+							}
+							Serial.print("Shield I2C Select: "); Serial.println(pinValue+1);
+							// i2cBus = 2;
+							enableStereoExtMicBias = 41;
 							CCP_atten1 = 52;  //enable attenuator #1.  Same as MOSI_2 (alt)
 							CCP_atten2 = 51;  //enable attenuator #2.  Same as MISO_2 (alt)
 							CCP_bigLED =  53;    //same as SCK_2 (alt)
-							CCP_littleLED = 41;    //same as AIC_Shield_enableStereoExtMicBias
+							CCP_littleLED_1 = 41;    //same as AIC_Shield_enableStereoExtMicBias
+							CCP_littleLED_2 = 8;     //prototype board variant uses TX_3 pin
 							CCP_enable28V = 5; //enable the 28V power supply.  Same as SS_2
 							defaultInput = AudioControlAIC3206::IN3;  //IN3 are the screw jacks
 							break;
 					}
 					break;
-					
+
 				case  (TympanRev::E) : case (TympanRev::E1) :  //we're connecting to a Rev E tympan, so the pin numbers below are correct for the TympanE
-				
+
 					switch (AICRev) {  //which AIC_shield are we connecting to?
-					
+
 						case (AICShieldRev::A) :    //Basic AIC shield (2019 and 2020)
 							//Teensy 4.1 Pin Numbering
 							resetAIC = 31;
 							i2cBus = 2;
-							enableStereoExtMicBias = 29; 
+							enableStereoExtMicBias = 29;
 							defaultInput = AudioControlAIC3206::IN3;  //IN3 is the pink mic/line jack
 							break;
-							
+
 						case (AICShieldRev::CCP):  case (AICShieldRev::CCP_A): //First generation CCP shield (May 2020)
 							//Teensy 4.1 Pin Numbering
 							resetAIC = 31;
 							i2cBus = 2;
-							enableStereoExtMicBias =29; 
+							enableStereoExtMicBias =29;
 							CCP_atten1 = 52;  //enable attenuator #1.  Same as MOSI_2 (alt)...NEED TO UPDATE!!!
 							CCP_atten2 = 51;  //enable attenuator #2.  Same as MISO_2 (alt)...NEED TO UPDATE!!!
 							CCP_bigLED =  53;    //same as SCK_2 (alt)...NEED TO UPDATE!!!
-							CCP_littleLED = 41;    //same as AIC_Shield_enableStereoExtMicBias...NEED TO UPDATE!!!
+							CCP_littleLED_1 = 41;    //same as AIC_Shield_enableStereoExtMicBias...NEED TO UPDATE!!!
+							CCP_littleLED_2 = 8;     //prototype board variant uses TX_3 pin
 							CCP_enable28V = 5; //enable the 28V power supply.  Same as SS_2...NEED TO UPDATE!!!
 							defaultInput = AudioControlAIC3206::IN3;  //IN3 are the screw jacks
 							break;
 					}
-					break;	
-				
+					break;
+
 				default:
 					Serial.println("AICSheildPins: *** WARNING *** This Teensy Rev is not supported.");
 					Serial.println("    : Assuming defaults and hoping for the best.");
@@ -114,45 +126,46 @@ class AICShieldPins {
 		//Defaults
 		TympanRev tympanRev = TympanRev::D;
 		AICShieldRev AICRev = AICShieldRev::A;
- 		int resetAIC = AICSHIELD_DEFAULT_RESET_PIN; 
+ 		int resetAIC = AICSHIELD_DEFAULT_RESET_PIN;
 		int i2cBus = AICSHIELD_DEFAULT_I2C_BUS;
 		int enableStereoExtMicBias = NOT_A_FEATURE;
 		int CCP_atten1 = NOT_A_FEATURE, CCP_atten2 = NOT_A_FEATURE;
-		int CCP_bigLED = NOT_A_FEATURE, CCP_littleLED = NOT_A_FEATURE;
+		int CCP_bigLED = NOT_A_FEATURE, CCP_littleLED_1 = NOT_A_FEATURE, CCP_littleLED_2 = NOT_A_FEATURE;
 		int CCP_enable28V = NOT_A_FEATURE;
 		int defaultInput = NOT_A_FEATURE;
-		
-	
+
+
 };
 
 
 class AICShieldBase : public AudioControlAIC3206
 {
 	public:
-		AICShieldBase(void) : 
-			AudioControlAIC3206(AICSHIELD_DEFAULT_RESET_PIN, AICSHIELD_DEFAULT_I2C_BUS) {
+		AICShieldBase(void) :
+			AudioControlAIC3206(pins.resetAIC, pins.i2cBus) {
 		}
-		AICShieldBase(bool _debugToSerial) : 
+		AICShieldBase(bool _debugToSerial) :
 			AudioControlAIC3206(AICSHIELD_DEFAULT_RESET_PIN, AICSHIELD_DEFAULT_I2C_BUS,_debugToSerial) {
 		}
-		AICShieldBase(const AICShieldPins &_pins) : 
+		AICShieldBase(const AICShieldPins &_pins) :
 			AudioControlAIC3206(_pins.resetAIC,_pins.i2cBus) {
+				Serial.print("resetAIC "); Serial.println(_pins.resetAIC);
 			setupPins(_pins);
 		}
-		AICShieldBase(const AICShieldPins &_pins, bool _debugToSerial) : 
+		AICShieldBase(const AICShieldPins &_pins, bool _debugToSerial) :
 			AudioControlAIC3206(_pins.resetAIC,_pins.i2cBus,_debugToSerial) {
 			setupPins(_pins);
 		}
-		AICShieldBase(const AudioSettings_F32 &_as) : 
+		AICShieldBase(const AudioSettings_F32 &_as) :
 			AudioControlAIC3206(AICSHIELD_DEFAULT_RESET_PIN, AICSHIELD_DEFAULT_I2C_BUS) {
 			setAudioSettings(_as);
 		}
-		AICShieldBase(const AICShieldPins &_pins, const AudioSettings_F32 &_as) : 
+		AICShieldBase(const AICShieldPins &_pins, const AudioSettings_F32 &_as) :
 			AudioControlAIC3206(_pins.resetAIC,_pins.i2cBus) {
 			setupPins(_pins);
 			setAudioSettings(_as);
 		}
-		AICShieldBase(const AICShieldPins &_pins, const AudioSettings_F32 &_as, bool _debugToSerial) : 
+		AICShieldBase(const AICShieldPins &_pins, const AudioSettings_F32 &_as, bool _debugToSerial) :
 			AudioControlAIC3206(_pins.resetAIC,_pins.i2cBus,_debugToSerial) {
 			setupPins(_pins);
 			setAudioSettings(_as);
@@ -160,25 +173,32 @@ class AICShieldBase : public AudioControlAIC3206
 
 		void setupPins(const AICShieldPins &_pins);
 		void setAudioSettings(const AudioSettings_F32 &_aud_set) { audio_settings = _aud_set; }  //shallow copy
-		virtual bool enable(void) { 
+		virtual bool enable(void) {
 			bool foo = AudioControlAIC3206::enable();
 			if (pins.defaultInput != NOT_A_FEATURE)	inputSelect(pins.defaultInput);
 			return foo;
 		}
-			
+
 
 		//TympanPins getTympanPins(void) { return &pins; }
 		int setBigLED_CCP(int _value) { if (pins.CCP_bigLED != NOT_A_FEATURE) { digitalWrite(pins.CCP_bigLED,_value); return _value; } return NOT_A_FEATURE;}
-		int setLittleLED_CCP(int _value) { if (pins.CCP_littleLED != NOT_A_FEATURE) { digitalWrite(pins.CCP_littleLED,_value); return _value; } return NOT_A_FEATURE;}
+		int setLittleLED_CCP(int _value) {
+			if (pins.CCP_littleLED_1 != NOT_A_FEATURE) {
+				digitalWrite(pins.CCP_littleLED_1,_value);
+				digitalWrite(pins.CCP_littleLED_2,_value);
+				return _value;
+			}
+			return NOT_A_FEATURE;
+		}
 		int enable28V_CCP(int _value) { if (pins.CCP_enable28V != NOT_A_FEATURE) { digitalWrite(pins.CCP_enable28V,_value); return _value; } return NOT_A_FEATURE; }
 		int enableCCPAtten1(int _value) { if (pins.CCP_atten1 != NOT_A_FEATURE) { digitalWrite(pins.CCP_atten1,_value); return _value; } return NOT_A_FEATURE; }
 		int enableCCPAtten2(int _value) { if (pins.CCP_atten2 != NOT_A_FEATURE) { digitalWrite(pins.CCP_atten2,_value); return _value; } return NOT_A_FEATURE; }
-	
+
 		int setEnableStereoExtMicBias(int new_state);
 
 		TympanRev getTympanRev(void) { return pins.tympanRev; }
 		AICShieldRev getAICRev(void) { return pins.AICRev; }
-	
+
 
 	protected:
 		AICShieldPins pins;
@@ -219,23 +239,23 @@ class AICShield : public AICShieldBase {
 
 class EarpieceShield : public AICShield {
 	public:
-		EarpieceShield(void) : 
-			AICShield() { 
+		EarpieceShield(void) :
+			AICShield() {
 		}
-		EarpieceShield(const TympanRev &_myRev, const AICShieldRev &_aicRev) : 
+		EarpieceShield(const TympanRev &_myRev, const AICShieldRev &_aicRev) :
 			AICShield(_myRev, _aicRev) {
 		}
-		EarpieceShield(const TympanRev &_myRev, const AICShieldRev &_aicRev, bool _debugToSerial) : 
-			AICShield(_myRev, _aicRev, _debugToSerial) {  
+		EarpieceShield(const TympanRev &_myRev, const AICShieldRev &_aicRev, bool _debugToSerial) :
+			AICShield(_myRev, _aicRev, _debugToSerial) {
 		}
-		EarpieceShield(const TympanRev &_myRev, const AICShieldRev &_aicRev, const AudioSettings_F32 &_as) : 
-			AICShield(_myRev, _aicRev, _as) { ; 
+		EarpieceShield(const TympanRev &_myRev, const AICShieldRev &_aicRev, const AudioSettings_F32 &_as) :
+			AICShield(_myRev, _aicRev, _as) { ;
 		}
-		EarpieceShield(const TympanRev &_myRev, const AICShieldRev &_aicRev, const AudioSettings_F32 &_as, bool _debugToSerial) : 
-			AICShield(_myRev, _aicRev,_as, _debugToSerial) { 
+		EarpieceShield(const TympanRev &_myRev, const AICShieldRev &_aicRev, const AudioSettings_F32 &_as, bool _debugToSerial) :
+			AICShield(_myRev, _aicRev,_as, _debugToSerial) {
 		}
-		
-		
+
+
 		//variables to simplify access to the Earpiece channel mapping...these are overwriten in setEarpiceValues()
 		//what I2S channel maps to what input or what output
 		static const int PDM_LEFT_FRONT, PDM_LEFT_REAR, PDM_RIGHT_FRONT, PDM_RIGHT_REAR;  //Front/Rear is weird.  Left/Right matches the enclosure labeling		.

--- a/src/AICShield.h
+++ b/src/AICShield.h
@@ -145,7 +145,7 @@ class AICShieldBase : public AudioControlAIC3206
 			AudioControlAIC3206(pins.resetAIC, pins.i2cBus) {
 		}
 		AICShieldBase(bool _debugToSerial) :
-			AudioControlAIC3206(AICSHIELD_DEFAULT_RESET_PIN, AICSHIELD_DEFAULT_I2C_BUS,_debugToSerial) {
+			AudioControlAIC3206(pins.resetAIC, pins.i2cBus,_debugToSerial) {
 		}
 		AICShieldBase(const AICShieldPins &_pins) :
 			AudioControlAIC3206(_pins.resetAIC,_pins.i2cBus) {
@@ -157,7 +157,7 @@ class AICShieldBase : public AudioControlAIC3206
 			setupPins(_pins);
 		}
 		AICShieldBase(const AudioSettings_F32 &_as) :
-			AudioControlAIC3206(AICSHIELD_DEFAULT_RESET_PIN, AICSHIELD_DEFAULT_I2C_BUS) {
+			AudioControlAIC3206(pins.resetAIC, pins.i2cBus) {
 			setAudioSettings(_as);
 		}
 		AICShieldBase(const AICShieldPins &_pins, const AudioSettings_F32 &_as) :

--- a/src/control_aic3206.cpp
+++ b/src/control_aic3206.cpp
@@ -1,10 +1,10 @@
-/* 
+/*
 	control_aic3206
-	
+
 	Created: Brendan Flynn (http://www.flexvoltbiosensor.com/) for Tympan, Jan-Feb 2017
 	Purpose: Control module for Texas Instruments TLV320AIC3206 compatible with Teensy Audio Library
 	Updates: Chip Audette (OpenAudio) 2017 through 2020+
- 
+
 	License: MIT License.  Use at your own risk.
  */
 
@@ -127,7 +127,7 @@
 	#define PRB_R                                                             1
 
 #endif  //for standard vs low-latency vs PDM setup
-	
+
 #endif // end fs if block
 
 //**************************** Chip Setup **********************************//
@@ -180,16 +180,26 @@ void AudioControlAIC3206::setI2Cbus(int i2cBusIndex)
 {
   // Setup for Master mode, pins 18/19, external pullups, 400kHz, 200ms default timeout
   switch (i2cBusIndex) {
-	case 0:
-		myWire = &Wire; break;
-	case 1:
-		myWire = &Wire1; break;  //defined in WireKinetis.h via Teensy's 
-	case 2:
-		myWire = &Wire2; break; //defined in WireKinetis.h via Teensy's Wire.h
-	//case 3:
-	//	myWire = &Wire3; break; //commented out in WireKinetis.h?? Why?
-	default:
-		myWire = &Wire; break;
+		case 0:
+			myWire = &Wire; break;
+		case 1:
+			myWire = &Wire1; break;  //defined in WireKinetis.h via Teensy's
+		case 2:
+			myWire = &Wire2; break; //defined in WireKinetis.h via Teensy's Wire.h
+		//case 3:
+		//	myWire = &Wire3; break; //commented out in WireKinetis.h?? Why?
+		case 4:
+			pinMode(7,INPUT_PULLUP); delay(10); int pinVal = digitalRead(7);
+			if(pinVal == 1){		// production Rev D
+				myWire = &Wire2;
+			} else {						// prototype Rev D with op amps
+				myWire = &Wire;
+				setResetPin(35);
+			}
+			Serial.print("Control I2C Select: "); Serial.println(pinVal+1);
+			break;
+		default:
+			myWire = &Wire; break;
   }
 }
 bool AudioControlAIC3206::enable(void) {
@@ -199,11 +209,11 @@ bool AudioControlAIC3206::enable(void) {
 
   //hard reset the AIC
   //Serial.print("AudioControlAIC3206: enable: Hardware reset of AIC on pin ");Serial.println(resetPinAIC);
-  pinMode(resetPinAIC,OUTPUT); 
+  pinMode(resetPinAIC,OUTPUT);
   digitalWrite(resetPinAIC,HIGH);delay(50); //not reset
   digitalWrite(resetPinAIC,LOW);delay(50);  //reset
   digitalWrite(resetPinAIC,HIGH);delay(50);//not reset
-	
+
   //if (debugToSerial) Serial.println("AudioControlAIC3206: enable: about to aic_reset...");
   aic_reset(); //delay(50);  //soft reset
   //if (debugToSerial) Serial.println("AudioControlAIC3206: enable: about to aic_init...");
@@ -240,7 +250,7 @@ bool AudioControlAIC3206::inputSelect(int n) {
     aic_writeRegister(TYMPAN_MICPGA_RIGHT_NEGATIVE_REG, TYMPAN_MIC_ROUTING_NEGATIVE_CM_TO_CM1L & TYMPAN_MIC_ROUTING_RESISTANCE_DEFAULT);
     // BIAS OFF
     setMicBias(TYMPAN_MIC_BIAS_OFF);
-	
+
 
     if (debugToSerial) Serial.println("Set Audio Input to Line In");
     return true;
@@ -313,24 +323,24 @@ bool AudioControlAIC3206::enableDigitalMicInputs(bool desired_state) {
 	if (desired_state == true) {
 		//change the AIC's pin "MFP4" to clock input for digital microphone
 		aic_writePage(0,55,0b00001110);  //page 0, register 55, bits D4-D1 to 0111
-		
+
 		//change the AIC's pin "MFP3" to Digital Microphone input
 		aic_writePage(0,56,0b00000010);  //page 0, register 56, bits D2-D1 to 01
-		
+
 		//change the ADC to use the digital mic
 		aic_writePage(0,81,0b11011100);  //page 0, register 81, Left+Right ADC powered, SCLK is Dig Mic In, Left+Right Dig Mic enabled, 1gain per word clock
-		
+
 		return true;
 	} else {
 		//change the AIC's pin "MFP4" to clock input for digital microphone
 		aic_writePage(0,55,0b00000010);  //page 0, register 55, set to "disabled" ???  is this the default state?
-		
+
 		//change the IAC's pin "MFP3" to Digital Microphone input
 		aic_writePage(0,56,0b00000010);  //page 0, register 56, set to "disabled" ???  is this the default state?
 
 		//change the ADC to NOT use the digital mic
 		aic_writePage(0,81,0b11000000);  //page 0, register 81, Left+Right ADC powered, GPIO as Dig Mic In, Left+Right Dig Mic disabled, gain per word clock
-		
+
 		return false;
 	}
 }
@@ -366,7 +376,7 @@ void AudioControlAIC3206::aic_initADC() {
   aic_writeRegister(TYMPAN_MICPGA_RIGHT_VOLUME_REG, TYMPAN_MICPGA_VOLUME_ENABLE); // enable Right MicPGA, set gain to 0 dB  //page is TYMPAN_MICPGA_PAGE
 
   //aic_writePage(1, 58, 0b11111100); // Anti-thump on aill input channels...doesn't seem to od anything here.  :(
-  
+
   aic_writeAddress(TYMPAN_ADC_MUTE_REG, TYMPAN_ADC_UNMUTE); // Unmute Left and Right ADC Digital Volume Control
   aic_writeAddress(TYMPAN_ADC_CHANNEL_POWER_REG, TYMPAN_ADC_CHANNELS_ON); // Unmute Left and Right ADC Digital Volume Control
 }
@@ -401,7 +411,7 @@ float AudioControlAIC3206::setInputGain_dB(float orig_gain_dB, int Ichan) {
 	}
 
 	if (Ichan == 0) {
-		aic_writePage(TYMPAN_MICPGA_PAGE, TYMPAN_MICPGA_LEFT_VOLUME_REG, TYMPAN_MICPGA_VOLUME_ENABLE | volume_int); // enable Left MicPGA 
+		aic_writePage(TYMPAN_MICPGA_PAGE, TYMPAN_MICPGA_LEFT_VOLUME_REG, TYMPAN_MICPGA_VOLUME_ENABLE | volume_int); // enable Left MicPGA
 	} else {
 		aic_writePage(TYMPAN_MICPGA_PAGE, TYMPAN_MICPGA_RIGHT_VOLUME_REG, TYMPAN_MICPGA_VOLUME_ENABLE | volume_int); // enable Right MicPGA
 	}
@@ -494,11 +504,11 @@ bool AudioControlAIC3206::outputSelect(int n, bool flag_full) {
 		flag_full = true;  //always do a full reconfiguration the first time through.
 		firstTime = false;
 	}
-	
-	// PLAYBACK SETUP: 
+
+	// PLAYBACK SETUP:
 	//	HPL/HPR are headphone output left and right
 	//	LOL/LOR are line output left and right
-	
+
 	if (flag_full) {
 		aic_writeAddress(TYMPAN_DAC_PROCESSING_BLOCK_REG, PRB_P); // processing blocks - DAC
 
@@ -508,16 +518,16 @@ bool AudioControlAIC3206::outputSelect(int n, bool flag_full) {
 		aic_writeRegister(17, 0b01000000); // page 1, mute HPR Driver, 0 gain
 		aic_writeRegister(18, 0b01000000); // page 1, mute LOL Driver, 0 gain
 		aic_writeRegister(19, 0b01000000); // page 1, mute LOR Driver, 0 gain
-		
+
 		aic_writePage(0, 63, 0); //disable LDAC/RDAC
-		
+
 		aic_goToPage(1);
 		aic_writeRegister( 9, 0); //page 1,  Power down HPL/HPR and LOL/LOR drivers
 		aic_writeRegister(12, 0); //page 1, unroute from HPL
 		aic_writeRegister(13, 0); //page 1, unroute from HPR
 		aic_writeRegister(14, 0); //page 1, unroute from LOL
-		aic_writeRegister(15, 0); //page 1, unroute from LOR	
-	
+		aic_writeRegister(15, 0); //page 1, unroute from LOR
+
 		//set the pop reduction settings, Page 1 Register 20 "Headphone Driver Startup Control"
 		aic_writeRegister(20, 0b10100101);  //soft routing step is 200ms, 5.0 time constants, assume 6K resistance
 	}
@@ -545,12 +555,12 @@ bool AudioControlAIC3206::outputSelect(int n, bool flag_full) {
 		if (debugToSerial) Serial.println("AudioControlAIC3206: Set Audio Output to Headphone Jack");
 		return true;
   } else if (n == TYMPAN_OUTPUT_LINE_OUT) {
-    
+
 		aic_goToPage(1);
 		//Register(1, 20, 0x25); //Page1, 0x14 De-Pop
 		aic_writeRegister(14, 0b00001000); //Page1, route LDAC/RDAC to LOL/LOR
 		aic_writeRegister(15, 0b00001000); //Page1, route LDAC/RDAC to LOL/LOR
-		if (flag_full)	aic_writePage(0, 63, 0xD6); // 0x3F // Power up LDAC/RDAC		
+		if (flag_full)	aic_writePage(0, 63, 0xD6); // 0x3F // Power up LDAC/RDAC
 		aic_goToPage(1);
 		aic_writeRegister(18, 0); //Page1, unmute LOL Driver, 0 gain
 		aic_writeRegister(19, 0); //Page1, unmute LOR Driver, 0 gain
@@ -570,18 +580,18 @@ bool AudioControlAIC3206::outputSelect(int n, bool flag_full) {
 		aic_writeRegister(13, 0b00001000); //Page 1, route LDAC/RDAC to HPL/HPR
 		aic_writeRegister(14, 0b00001000); //Page 1, route LDAC/RDAC to LOL/LOR
 		aic_writeRegister(15, 0b00001000); //Page 1, route LDAC/RDAC to LOL/LOR
-		
+
 		if (flag_full) aic_writePage(0, 63, 0xD6); // 0x3F // Power up LDAC/RDAC
-		
+
 		aic_goToPage(1);
 		aic_writeRegister(18, 0); //Page 1, unmute LOL Driver, 0 gain
-		aic_writeRegister(19, 0); //Page 1, unmute LOR Driver, 0 gain		
+		aic_writeRegister(19, 0); //Page 1, unmute LOR Driver, 0 gain
 		aic_writeRegister(16, 0); //Page 1, unmute HPL Driver, 0 gain
 		aic_writeRegister(17, 0); //Page 1, unmute HPR Driver, 0 gain
 
 		if (flag_full) {
-			aic_writePage(1, 9, 0b00111100);       // Power up both the HPL/HPR and the LOL/LOR drivers  
-			
+			aic_writePage(1, 9, 0b00111100);       // Power up both the HPL/HPR and the LOL/LOR drivers
+
 			delay(50);
 			aic_writeAddress(TYMPAN_DAC_VOLUME_LEFT_REG,  0); // default to 0 dB
 			aic_writeAddress(TYMPAN_DAC_VOLUME_RIGHT_REG, 0); // default to 0 dB
@@ -589,26 +599,26 @@ bool AudioControlAIC3206::outputSelect(int n, bool flag_full) {
 		}
 
 		if (debugToSerial) Serial.println("AudioControlAIC3206: Set Audio Output to Headphone Jack and Line out");
-		return true;	
+		return true;
   } else if (n == TYMPAN_OUTPUT_LEFT2DIFFHP_AND_R2DIFFLO) {
-	  
+
 		aic_goToPage(1);
 		aic_writeRegister(12, 0b00001000); //Page 1, route Left DAC Pos to Headphone Left
 		aic_writeRegister(13, 0b00010000); //Page 1, route Left DAC Neg to Headphone Right
 		aic_writeRegister(14, 0b00010000); //Page 1, route Right DAC Neg to Lineout Left
 		aic_writeRegister(15, 0b00001000); //Page 1, route Right DAC Pos to Lineout Right
-		
+
 		if (flag_full) aic_writePage(0, 63, 0xD6); // 0x3F // Power up LDAC/RDAC
-		
+
 		aic_goToPage(1);
 		aic_writeRegister(18, 0); //Page 1, unmute LOL Driver, 0 gain
-		aic_writeRegister(19, 0); //Page 1, unmute LOR Driver, 0 gain		
+		aic_writeRegister(19, 0); //Page 1, unmute LOR Driver, 0 gain
 		aic_writeRegister(16, 0); //Page 1, unmute HPL Driver, 0 gain
 		aic_writeRegister(17, 0); //Page 1, unmute HPR Driver, 0 gain
 
 		if (flag_full) {
-			aic_writePage(1, 9, 0b00111100);       // Power up both the HPL/HPR and the LOL/LOR drivers  
-			
+			aic_writePage(1, 9, 0b00111100);       // Power up both the HPL/HPR and the LOL/LOR drivers
+
 			delay(50);
 			aic_writeAddress(TYMPAN_DAC_VOLUME_LEFT_REG,  0); // default to 0 dB
 			aic_writeAddress(TYMPAN_DAC_VOLUME_RIGHT_REG, 0); // default to 0 dB
@@ -616,7 +626,7 @@ bool AudioControlAIC3206::outputSelect(int n, bool flag_full) {
 		}
 
 		if (debugToSerial) Serial.println("AudioControlAIC3206: Set Audio Output to Diff Headphone Jack and Line out");
-		return true;			
+		return true;
   }
   Serial.print("AudioControlAIC3206: ERROR: Unable to Select Output - Value not supported: ");
   Serial.println(n);
@@ -636,15 +646,15 @@ void AudioControlAIC3206::muteLineOut(bool flag) {
 		} else {
 			//mute
 			aic_writeRegister(18,curValL & 0b10111111); //Page1, mute LOL driver, same gain as before
-		}		
+		}
 		//unmute
 		if (!(curValR & 0b01000000))  { //is this bit low?
 			//already muted
 		} else {
 			//mute
 			aic_writeRegister(19,curValR & 0b10111111); //Page1, mute LOR driver, same gain as before
-		}	
-	
+		}
+
 	} else {
 		//unmute
 		if (curValL & 0b01000000)  {   //is this bit high?
@@ -652,20 +662,20 @@ void AudioControlAIC3206::muteLineOut(bool flag) {
 		} else {
 			//unmute
 			aic_writeRegister(18,curValL | 0b0100000000); //Page1, unmute LOL driver, same gain as before
-		}		
+		}
 		//unmute
 		if (curValR & 0b01000000)  { //is this bit high?
 			//already active
 		} else {
 			//unmute
 			aic_writeRegister(19,curValR | 0b0100000000); //Page1, unmute LOR driver, same gain as before
-		}			
+		}
 	}
 }
 
 void AudioControlAIC3206::aic_init() {
   if (debugToSerial) Serial.println("AudioControlAIC3206: Initializing AIC");
-  
+
   // PLL
   aic_goToPage(0);
   aic_writeRegister(4, 3); // page 0, 0x04 low PLL clock range, MCLK is PLL input, PLL_OUT is CODEC_CLKIN
@@ -847,15 +857,15 @@ int AudioControlAIC3206::readMicDetect(void) {
 
 
 
-float AudioControlAIC3206::setBiquadOnADC(int type, float cutoff_Hz, float sampleRate_Hz, int chanIndex, int biquadIndex) 
+float AudioControlAIC3206::setBiquadOnADC(int type, float cutoff_Hz, float sampleRate_Hz, int chanIndex, int biquadIndex)
 {
-	//Purpose: Creare biquad filter coefficients to be applied within 3206 hardware, ADC (input) side	
+	//Purpose: Creare biquad filter coefficients to be applied within 3206 hardware, ADC (input) side
 	//
 	// type is type of filter: 1 = Lowpass, 2=highpass
 	// cutoff_Hz is the cutoff frequency in Hz
 	// chanIndex is 0=both, 1=left, 2=right
 	// biquadIndex is 0-4 for biquad A through biquad B, depending upon ADC mode
-	
+
 	const int ncoeff = 5;
 	float coeff_f32[ncoeff];
 	uint32_t coeff_uint32[ncoeff];
@@ -874,14 +884,14 @@ float AudioControlAIC3206::setBiquadOnADC(int type, float cutoff_Hz, float sampl
 	setBiquadCoeffOnADC(chanIndex, biquadIndex, coeff_uint32); //needs twos-compliment
 	return cutoff_Hz;
 }
-	
+
 
 void AudioControlAIC3206::computeBiquadCoeff_LP_f32(float freq_Hz, float sampleRate_Hz, float q, float *coeff) {
 	// Compute common filter functions...all second order filters...all with Matlab convention on a1 and a2 coefficients
 	// http://www.musicdsp.org/files/Audio-EQ-Cookbook.txt
-	
+
 	//cutoff_Hz = freq_Hz;
-	
+
 	//int coeff[5];
 	double w0 = freq_Hz * (2.0 * 3.141592654 / sampleRate_Hz);
 	double sinW0 = sin(w0);
@@ -893,21 +903,21 @@ void AudioControlAIC3206::computeBiquadCoeff_LP_f32(float freq_Hz, float sampleR
 	/* b1 */ coeff[1] = (1.0 - cosW0) * scale;
 	/* b2 */ coeff[2] = coeff[0];
 	/* a0 = 1.0 in Matlab style */
-	/* a1 */ coeff[3] = (-2.0 * cosW0) * scale;  
-	/* a2 */ coeff[4] = (1.0 - alpha) * scale;  
-	
+	/* a1 */ coeff[3] = (-2.0 * cosW0) * scale;
+	/* a2 */ coeff[4] = (1.0 - alpha) * scale;
+
 	//flip signs for TI convention...see section 2.3.3.1.10.2 of TI Application Guide http://www.ti.com/lit/an/slaa463b/slaa463b.pdf
 	coeff[1] = coeff[1]/2.0;
 	coeff[3] = -coeff[3]/2.0;
-	coeff[4] = -coeff[4];	
+	coeff[4] = -coeff[4];
 }
 
 void AudioControlAIC3206::computeBiquadCoeff_HP_f32(float freq_Hz, float sampleRate_Hz, float q, float *coeff) {
 	// Compute common filter functions...all second order filters...all with Matlab convention on a1 and a2 coefficients
 	// http://www.musicdsp.org/files/Audio-EQ-Cookbook.txt
-	
+
 	//cutoff_Hz = freq_Hz;
-	
+
 	double w0 = freq_Hz * (2 * 3.141592654 / sampleRate_Hz);
 	double sinW0 = sin(w0);
 	double alpha = sinW0 / ((double)q * 2.0);
@@ -917,9 +927,9 @@ void AudioControlAIC3206::computeBiquadCoeff_HP_f32(float freq_Hz, float sampleR
 	/* b1 */ coeff[1] = -(1.0 + cosW0) * scale;
 	/* b2 */ coeff[2] = coeff[0];
 	/* a0 = 1.0 in Matlab style */
-	/* a1 */ coeff[3] = (-2.0 * cosW0) * scale; 
-	/* a2 */ coeff[4] = (1.0 - alpha) * scale;  
-	
+	/* a1 */ coeff[3] = (-2.0 * cosW0) * scale;
+	/* a2 */ coeff[4] = (1.0 - alpha) * scale;
+
 	//flip signs and scale for TI convention...see section 2.3.3.1.10.2 of TI Application Guide http://www.ti.com/lit/an/slaa463b/slaa463b.pdf
 	coeff[1] = coeff[1]/2.0;
 	coeff[3] = -coeff[3]/2.0;
@@ -934,7 +944,7 @@ void AudioControlAIC3206::computeBiquadCoeff_HP_f32(float freq_Hz, float sampleR
 //	for (int i=0; i<3; i++) {
 //		//scale
 //		coeff_f32[i] *= (float)CONST_2_31_m1;
-//		
+//
 //		//truncate
 //		coeff[i] = (int32_t)coeff_f32[i];
 //	}
@@ -943,7 +953,7 @@ void AudioControlAIC3206::convertCoeff_f32_to_i32(float *coeff_f32, int32_t *coe
 	for (int i=0; i< ncoeff; i++) {
 		//scale
 		coeff_f32[i] *= (float)CONST_2_31_m1;
-		
+
 		//truncate
 		coeff_i32[i] = (int32_t)coeff_f32[i];
 	}
@@ -953,48 +963,48 @@ int AudioControlAIC3206::setBiquadCoeffOnADC(int chanIndex, int biquadIndex, uin
 {
 	//See TI application guide for the AIC3206 http://www.ti.com/lit/an/slaa463b/slaa463b.pdf
 	//See section 2.3.3.1.10.2
-		
+
 	//power down the AIC to allow change in coefficients
 	uint32_t prev_state = aic_readPage(0x00,0x51);
 	aic_writePage(0x00,0x51,prev_state & (0b00111111));  //clear first two bits
-	
+
 	//use table 2-14 from TI Application Guide...
-	int page_reg_table[]={ 
+	int page_reg_table[]={
 		8, 36, 9, 44,   // N0, start of Biquad A
 		8, 40, 9, 48,   // N1
 		8, 44, 9, 52,   // N2
 		8, 48, 9, 56,   // D1
 		8, 52, 8, 64,   // D2
 		8, 56, 9, 64,    // start of biquad B
-		8, 60, 9, 68, 
-		8, 64, 9, 72, 
-		8, 68, 9, 76, 
-		8, 72, 9, 80, 
+		8, 60, 9, 68,
+		8, 64, 9, 72,
+		8, 68, 9, 76,
+		8, 72, 9, 80,
 		8, 76, 9, 84,   // start of Biquad C
-		8, 80, 9, 88, 
-		8, 84, 9, 92, 
-		8, 88, 9, 96, 
-		8, 92, 9, 100, 
+		8, 80, 9, 88,
+		8, 84, 9, 92,
+		8, 88, 9, 96,
+		8, 92, 9, 100,
 		8, 96, 9, 104,   // start of Biquad D
 		8, 100, 9, 108,
-		8, 104, 9, 112, 
-		8, 108, 9, 116, 
-		8, 112, 9, 120, 
+		8, 104, 9, 112,
+		8, 108, 9, 116,
+		8, 112, 9, 120,
 		8, 116, 9, 124,  //start of Biquad E
-		8, 120, 10, 8, 
-		8, 124, 10, 12, 
-		9, 8, 10, 16, 
-	    9, 12, 10, 20 
+		8, 120, 10, 8,
+		8, 124, 10, 12,
+		9, 8, 10, 16,
+	    9, 12, 10, 20
 	};
-		
+
 	const int rows_per_biquad = 5;
 	const int table_ncol = 4;
 	int chan_offset;
-	
+
 	switch (chanIndex) {
 		case BOTH_CHAN:
 			chan_offset = 0;
-			writeBiquadCoeff(coeff_uint32, page_reg_table + chan_offset + biquadIndex*rows_per_biquad*table_ncol,table_ncol);		
+			writeBiquadCoeff(coeff_uint32, page_reg_table + chan_offset + biquadIndex*rows_per_biquad*table_ncol,table_ncol);
 			chan_offset = 1;
 			writeBiquadCoeff(coeff_uint32, page_reg_table + chan_offset + biquadIndex*rows_per_biquad*table_ncol,table_ncol);
 			break;
@@ -1009,8 +1019,8 @@ int AudioControlAIC3206::setBiquadCoeffOnADC(int chanIndex, int biquadIndex, uin
 		default:
 			return -1;
 			break;
-	}	
-	
+	}
+
 	//power the ADC back up
 	aic_writePage(0x00,0x51,prev_state);  //clear first two bits
 	return 0;
@@ -1025,17 +1035,17 @@ void AudioControlAIC3206::writeBiquadCoeff(uint32_t *coeff_uint32, int *page_reg
 		c = coeff_uint32[i];
 		aic_writePage(page,reg,(uint8_t)(c>>24));
 		aic_writePage(page,reg+1,(uint8_t)(c>>16));
-		aic_writePage(page,reg+2,(uint8_t)(c>>8));	
+		aic_writePage(page,reg+2,(uint8_t)(c>>8));
 	}
 	return;
-}	
+}
 
-	
+
 void AudioControlAIC3206::setHPFonADC(bool enable, float cutoff_Hz, float fs_Hz) { //fs_Hz is sample rate
 	//see TI application guide Section 2.3.3.1.10.1: http://www.ti.com/lit/an/slaa463b/slaa463b.pdf
 	uint32_t coeff[3];
 	if (enable) {
-		HP_cutoff_Hz = cutoff_Hz; 
+		HP_cutoff_Hz = cutoff_Hz;
 		#if 0
 			//original
 			sample_rate_Hz = fs_Hz;
@@ -1046,7 +1056,7 @@ void AudioControlAIC3206::setHPFonADC(bool enable, float cutoff_Hz, float fs_Hz)
 			computeFirstOrderHPCoeff_f32(cutoff_Hz, fs_Hz, coeff_f32);
 			convertCoeff_f32_to_i32(coeff_f32, (int32_t *)coeff, 3);
 		#endif
-		
+
 		//Serial.print("enableHPFonADC: coefficients, Hex: ");
 		//Serial.print(coeff[0],HEX);
 		//Serial.print(", ");
@@ -1054,15 +1064,15 @@ void AudioControlAIC3206::setHPFonADC(bool enable, float cutoff_Hz, float fs_Hz)
 		//Serial.print(", ");
 		//Serial.print(coeff[2],HEX);
 		//Serial.println();
-		
+
 	} else {
 		//disable
 		HP_cutoff_Hz = cutoff_Hz;
-		
+
 		//see Table 5-4 in TI application guide  Coeff C4, C5, C6
 		coeff[0] = 0x7FFFFFFF; coeff[1] = 0; coeff[2]=0;
 	}
-	
+
 	setHpfIIRCoeffOnADC(BOTH_CHAN, coeff); //needs twos-compliment
 }
 
@@ -1070,7 +1080,7 @@ void AudioControlAIC3206::setHPFonADC(bool enable, float cutoff_Hz, float fs_Hz)
 void AudioControlAIC3206::computeFirstOrderHPCoeff_f32(float cutoff_Hz, float fs_Hz, float *coeff) {
 	//cutoff_Hz is the cutoff frequency in Hz
 	//fs_Hz is the sample rate in Hz
-	
+
 	//First-order Butterworth IIR
 	//From https://www.dsprelated.com/showcode/199.php
 	const float pi = 3.141592653589793;
@@ -1090,7 +1100,7 @@ void AudioControlAIC3206::setHpfIIRCoeffOnADC(int chan, uint32_t *coeff) {
 	//power down the AIC to allow change in coefficients
 	uint32_t prev_state = aic_readPage(0x00,0x51);
 	aic_writePage(0x00,0x51,prev_state & (0b00111111));  //clear first two bits
-	
+
 	if (chan == BOTH_CHAN) {
 		setHpfIIRCoeffOnADC_Left(coeff);
 		setHpfIIRCoeffOnADC_Right(coeff);
@@ -1103,13 +1113,13 @@ void AudioControlAIC3206::setHpfIIRCoeffOnADC(int chan, uint32_t *coeff) {
 	//power the ADC back up
 	aic_writePage(0x00,0x51,prev_state);  //clear first two bits
 }
-		
+
 void AudioControlAIC3206::setHpfIIRCoeffOnADC_Left(uint32_t *coeff) {
 	int page;
 	uint32_t c;
-	
+
 	//See TI AIC3206 Application Guide, Table 2-13: http://www.ti.com/lit/an/slaa463b/slaa463b.pdf
-	
+
 	//Coeff N0, Coeff C4
 	page = 8;
 	c = coeff[0];
@@ -1123,19 +1133,19 @@ void AudioControlAIC3206::setHpfIIRCoeffOnADC_Left(uint32_t *coeff) {
 	aic_writePage(page,28,(uint8_t)(c>>24));
 	aic_writePage(page,29,(uint8_t)(c>>16));
 	aic_writePage(page,30,(uint8_t)(c>>8));
-	
+
 	//Coeff N2, Coeff C6
 	c = coeff[2];
 	aic_writePage(page,32,(uint8_t)(c>>24));
 	aic_writePage(page,33,(uint8_t)(c>>16));
-	aic_writePage(page,34,(uint8_t)(c>>8));	
+	aic_writePage(page,34,(uint8_t)(c>>8));
 }
 void AudioControlAIC3206::setHpfIIRCoeffOnADC_Right(uint32_t *coeff) {
 	int page;
 	uint32_t c;
-	
+
 	//See TI AIC3206 Application Guide, Table 2-13: http://www.ti.com/lit/an/slaa463b/slaa463b.pdf
-				
+
 	//Coeff N0, Coeff C36
 	page = 9;
 	c = coeff[0];
@@ -1148,7 +1158,7 @@ void AudioControlAIC3206::setHpfIIRCoeffOnADC_Right(uint32_t *coeff) {
 	aic_writePage(page,36,(uint8_t)(c>>24));
 	aic_writePage(page,37,(uint8_t)(c>>16));
 	aic_writePage(page,38,(uint8_t)(c>>8));
-	
+
 	//Coeff N2, Coeff C39
 	c = coeff[2];;
 	aic_writePage(page,40,(uint8_t)(c>>24));
@@ -1161,7 +1171,7 @@ bool AudioControlAIC3206::mixInput1toHPout(bool state) {
 	int page = 1;
 	int reg;
 	uint8_t val;
-	
+
 	//loop over both channels
 	for (reg = 12; reg <= 13; reg++) { //reg 12 is Left, reg 13 is right
 		val = aic_readPage(page,reg);

--- a/src/control_aic3206.h
+++ b/src/control_aic3206.h
@@ -19,14 +19,14 @@
 #define TYMPAN_INPUT_LINE_IN            (AudioControlAIC3206::IN1)   //uses IN1, on female Arduino-style headers (shared with BT Audio)
 #define TYMPAN_INPUT_BT_AUDIO	        (AudioControlAIC3206::IN1)   //uses IN1, for Bluetooth Audio (ahred with LINE_IN)
 #define TYMPAN_INPUT_ON_BOARD_MIC       (AudioControlAIC3206::IN2)   //uses IN2, for analog signals from microphones on PCB
-#define TYMPAN_INPUT_JACK_AS_LINEIN     (AudioControlAIC3206::IN3)   //uses IN3, for analog signals from mic jack, no mic bias 
+#define TYMPAN_INPUT_JACK_AS_LINEIN     (AudioControlAIC3206::IN3)   //uses IN3, for analog signals from mic jack, no mic bias
 #define TYMPAN_INPUT_JACK_AS_MIC        (AudioControlAIC3206::IN3_wBIAS)   //uses IN3, for analog signals from mic jack, with mic bias
 
 
 //convenience names to use with outputSelect()
 #define TYMPAN_OUTPUT_HEADPHONE_JACK_OUT 1  //DAC left and right to headphone left and right
 #define TYMPAN_OUTPUT_LINE_OUT 2 //DAC left and right to lineout left and right
-#define TYMPAN_OUTPUT_HEADPHONE_AND_LINE_OUT 3  //DAC left and right to both headphone and line out 
+#define TYMPAN_OUTPUT_HEADPHONE_AND_LINE_OUT 3  //DAC left and right to both headphone and line out
 #define TYMPAN_OUTPUT_LEFT2DIFFHP_AND_R2DIFFLO 4 //DAC left to differential headphone, DAC right to line out
 
 //names to use with setMicBias() to set the amount of bias voltage to use
@@ -42,7 +42,7 @@
 #define RIGHT_CHAN 2
 
 //define AIC3206_DEFAULT_I2C_BUS 0   //bus zero is &Wire
-#define AIC3206_DEFAULT_RESET_PIN 21
+#define AIC3206_DEFAULT_RESET_PIN 42
 
 class AudioControlAIC3206: public TeensyAudioControl
 {
@@ -50,31 +50,31 @@ public:
 	//GUI: inputs:0, outputs:0  //this line used for automatic generation of GUI node
 	AudioControlAIC3206(void) {   //specify nothing
 		//setI2Cbus(AIC3206_DEFAULT_I2C_BUS);
-		debugToSerial = false; 
+		debugToSerial = false;
 	}
 	AudioControlAIC3206(bool _debugToSerial) {  //specify debug
 		//setI2Cbus(AIC3206_DEFAULT_I2C_BUS);
-		debugToSerial = _debugToSerial;		
+		debugToSerial = _debugToSerial;
 	}
 	AudioControlAIC3206(int _resetPin) {  //specify reset pin (minimum recommended!)
-		resetPinAIC = _resetPin; 
+		resetPinAIC = _resetPin;
 		//setI2Cbus(AIC3206_DEFAULT_I2C_BUS);
-		debugToSerial = false; 
-	}	
+		debugToSerial = false;
+	}
 	AudioControlAIC3206(int _resetPin, int i2cBusIndex) {  //specify reset pin and i2cBus (minimum if using for 2nd AIC)
-		setResetPin(_resetPin); 
+		setResetPin(_resetPin);
 		setI2Cbus(i2cBusIndex);
-		debugToSerial = false; 
+		debugToSerial = false;
 	}
 	AudioControlAIC3206(int _resetPin, int i2cBusIndex, bool _debugToSerial) {  //specify everything
-		setResetPin(_resetPin); 
+		setResetPin(_resetPin);
 		setI2Cbus(i2cBusIndex);
 		debugToSerial = _debugToSerial;
 	}
 	enum INPUTS {IN1 = 0, IN2, IN3, IN3_wBIAS};
 	virtual bool enable(void);
 	virtual bool disable(void);
-	bool outputSelect(int n, bool flag_full = true); //flag_full is whether to do a full reconfiguration.  True is more complete but false is faster. 
+	bool outputSelect(int n, bool flag_full = true); //flag_full is whether to do a full reconfiguration.  True is more complete but false is faster.
 	bool volume(float n);
 	static float applyLimitsOnVolumeSetting(float vol_dB);
 	float volume_dB(float vol_dB);  //set both channels to the same volume
@@ -82,7 +82,7 @@ public:
 	float volume_dB(float vol_left_dB, int chan); //set each channel seperately (0 = left; 1 = right)
 	bool inputLevel(float n);  //dummy to be compatible with Teensy Audio Library
 	bool inputSelect(int n);
-	float applyLimitsOnInputGainSetting(float gain_dB);  
+	float applyLimitsOnInputGainSetting(float gain_dB);
 	float setInputGain_dB(float gain_dB);   //set both channels to the same gain
 	float setInputGain_dB(float gain_dB, int chan); //set each channel seperately (0 = left; 1 = right)
 	bool setMicBias(int n);
@@ -92,21 +92,21 @@ public:
 	bool debugToSerial;
     unsigned int aic_readPage(uint8_t page, uint8_t reg);
     bool aic_writePage(uint8_t page, uint8_t reg, uint8_t val);
-	
+
 	void setHPFonADC(bool enable, float cutoff_Hz, float fs_Hz); //first-order HP applied within this 3206 hardware, ADC (input) side
 	float getHPCutoff_Hz(void) { return HP_cutoff_Hz; }
 	void setHpfIIRCoeffOnADC(int chan, uint32_t *coeff); //alternate way of settings the same 1st-order HP filter
 	float setBiquadOnADC(int type, float cutoff_Hz, float sampleRate_Hz, int chan, int biquadIndex); //lowpass applied within 3206 hardware, ADC (input) side
 	int setBiquadCoeffOnADC(int chanIndex, int biquadIndex, uint32_t *coeff_uint32);
 	void writeBiquadCoeff(uint32_t *coeff_uint32, int *page_reg_table, int table_ncol);
-	
+
 	float getSampleRate_Hz(void) { return sample_rate_Hz; }
 	bool enableAutoMuteDAC(bool, uint8_t);
 	bool mixInput1toHPout(bool state);
 	void muteLineOut(bool state);
 	bool enableDigitalMicInputs(void) { return enableDigitalMicInputs(true); }
 	bool enableDigitalMicInputs(bool desired_state);
-	
+
 protected:
   TwoWire *myWire = &Wire;  //from Wire.h
   void setI2Cbus(int i2cBus);
@@ -115,7 +115,7 @@ protected:
   void aic_initDAC(void);
   void aic_initADC(void);
   void setResetPin(int pin) { resetPinAIC = pin; }
-  
+
   bool aic_writeAddress(uint16_t address, uint8_t val);
   bool aic_goToPage(uint8_t page);
   bool aic_writeRegister(uint8_t reg, uint8_t val);  //assumes page has already been set
@@ -132,7 +132,7 @@ protected:
   void computeBiquadCoeff_HP_f32(float cutoff_Hz, float sampleRate_Hz, float q, float *coeff);
   void convertCoeff_f32_to_i32(float *coeff_f32, int32_t *coeff_i32, int ncoeff);
 
-  
+
 };
 
 


### PR DESCRIPTION
Added support for Tympan Rev D board variant used in 9 units of the CCP/Dosimeter production run.
This adds checking a pin value to determine target board variant and sets pins accordingly.

1. Shield AIC reset pin selection
2. I2C bus selection
3. littleLED control pin