### PR TITLE
Fix compiler warning in SerialManagerBase.cpp

### DIFF
--- a/src/SerialManagerBase.cpp
+++ b/src/SerialManagerBase.cpp
@@ -47,8 +47,9 @@ void SerialManagerBase::respondToByte(char c) {
       break;
     case STREAM_LENGTH:
       if (c == DATASTREAM_SEPARATOR) {
-        // Get the datastream length:
-        stream_length = *((int*)(stream_data));
+        // Get the datastream length from stream_data.
+        int* stream_data_as_int = reinterpret_cast<int*>(stream_data);
+        stream_length = *stream_data_as_int;
         serial_read_state = STREAM_DATA;
         stream_chars_received = 0;
         Serial.print("SerialManagerBase: RespondToByte: Stream length = ");


### PR DESCRIPTION
When I compile the first example (AudioPassThru) I get this warning:
/Users/jamescook/Documents/Arduino/libraries/Tympan_Library/src/SerialManagerBase.cpp: In member function 'virtual void SerialManagerBase::respondToByte(char)':
/Users/jamescook/Documents/Arduino/libraries/Tympan_Library/src/SerialManagerBase.cpp:56:46: warning: dereferencing type-punned pointer will break strict-aliasing rules [-Wstrict-aliasing]
         stream_length = *((int*)(stream_data));

The warning comes from the cast of byte stream_data[SIZE] to int*. See
https://www.ibm.com/docs/en/ztpf/1.1.0.14?topic=warnings-type-pun-problems

Since the code appears to be correct, use reinterpret_cast<> and a
separate local variable to avoid the warning.

This is my first github pull request, please let me know if I'm doing something wrong. :-)