### PR TITLE
Merge Feature_Add_Callback... to Main

### DIFF
--- a/src/SerialManagerBase.cpp
+++ b/src/SerialManagerBase.cpp
@@ -48,11 +48,21 @@ void SerialManagerBase::respondToByte(char c) {
     case STREAM_LENGTH:
       if (c == DATASTREAM_SEPARATOR) {
         // Get the datastream length:
-        memcpy(&stream_length, &stream_data[0], 4);
-        serial_read_state = STREAM_DATA;
-        stream_chars_received = 0;
-        Serial.print("SerialManagerBase: RespondToByte: Stream length = ");
-        Serial.println(stream_length);
+        if (stream_chars_received==4) {
+          memcpy(&stream_length, &stream_data[0], 4);
+          serial_read_state = STREAM_DATA;
+          stream_chars_received = 0;
+          Serial.print("SerialManagerBase: RespondToByte: Stream length = ");
+          Serial.println(stream_length);
+        } 
+        // Error, length must be 4-byte int
+        else {
+          Serial.println("Error: Message length must be 4 byte Int");
+          //Reset for next message
+          serial_read_state = SINGLE_CHAR;
+          stream_chars_received = 0;
+        }
+
       } else {
         stream_data[stream_chars_received] = c;
         stream_chars_received++;
@@ -122,10 +132,11 @@ bool SerialManagerBase::processCharacter(char c) {
 void SerialManagerBase::processStream(void) {
   int idx = 0;
   String streamType;
-  int tmpInt;
-  float tmpFloat;
+  int tmpInt = 0;
+  float tmpFloat = 0;
   
-  while (stream_data[idx] != DATASTREAM_SEPARATOR) {
+  //Look for message type by finding the next separating character 
+  while ( (stream_data[idx] != DATASTREAM_SEPARATOR) && (idx < stream_length) ) {
     streamType.append(stream_data[idx]);
     idx++;
   }
@@ -145,23 +156,29 @@ void SerialManagerBase::processStream(void) {
     //interpretStreamAFC(idx);
   } else if (streamType == "test") {    
     Serial.println("Stream is of type 'test'.");
-    
-    //Print first 4-bytes as integer
-    memcpy(&tmpInt, stream_data+idx, 4);
-    idx = idx+4;
-    Serial.print("int is "); Serial.println(tmpInt);
-    
-    //And second 4-bytes as float
-    memcpy(&tmpFloat, stream_data+idx, 4);
-    Serial.print("float is "); Serial.println(tmpFloat);
 
+    //Print first 4-bytes as integer
+    if ( (stream_length-idx) >= 4) {
+      memcpy(&tmpInt, stream_data+idx, 4);
+      idx = idx+4;
+      Serial.print("int is "); Serial.println(tmpInt);
+    }
+
+    //Print the next 4-bytes as float
+    if (stream_length-idx >= 4) {    
+      memcpy(&tmpFloat, stream_data+idx, 4);
+      Serial.print("float is "); Serial.println(tmpFloat);
+    }
+  
+  // Else the message type was not identifued
   } else {
-    // Check if a custom callback was set
+    // If a custom callback was set, call it
     if (_datastreamCallback_p!=NULL)
     {
       _datastreamCallback_p(stream_data+idx, &streamType, stream_length-idx);
     }
-    // No way to handle the message so ignore it
+
+    // Else no message type found, so ignore it
     else
     {
       Serial.print("Unknown stream type: ");

--- a/src/SerialManagerBase.h
+++ b/src/SerialManagerBase.h
@@ -164,7 +164,7 @@ class SerialManagerBase {
     
     int serial_read_state; // Are we reading one character at a time, or a stream?
     char stream_data[MAX_DATASTREAM_LENGTH];
-    int stream_length;
+    int stream_length = 0;
     int stream_chars_received;
     BLE *ble;
     char GUI_persistent_mode = 'g';  //is this used?  I don't think so.

--- a/src/SerialManagerBase.h
+++ b/src/SerialManagerBase.h
@@ -75,9 +75,39 @@
 			 inadvertently invoking these modes, never send characters such as 0x02, 0x03, 0x04.
 			 In fact, you should generally avoid any non-printable character or you risk seeing
 			 unexpected behavior.
-	
-	License: MIT License.  Use at your own risk.  Have fun!
 
+			 Datastreams expect the following message protocol.  Note that the message length and payload are sent as little endian (LSB, MSB):
+			 	1.	DATASTREAM_START_CHAR 	(0x02)
+				2.	Message Length (int32): number of bytes including parts-4 thru part-6
+				3.	DATASTREAM_SEPARATOR 	(0x03)
+				4.	Message Type (char): Avoid using the special characters 0x03 or 0x04.  (if set to ‘test’, it will print out the payload as an int, then a float)
+				5.	DATASTREAM_SEPARATOR 	(0x03)
+				6.	Payload
+				7.	DATASTREAM_END_CHAR 	(0x04)
+
+			Use RealTerm to send a 'test' message: 
+			0x02 0x0D 0x00 0x00 0x00 0x03 0x74 0x65 0x73 0x74 0x03 0xD2 0x02 0x96 0x49 0xD2 0x02 0x96 0x49 0x04
+				1. DATASTREAM_START_CHAR 	(0x02)
+				2.	Message Length (int32): (0x000D) = 13 
+				3.	DATASTREAM_SEPARATOR 	(0x03)
+				4.	Message Type (char): 	(0x74657374) = 'test'
+				5.	DATASTREAM_SEPARATOR 	(0x03)
+				6.	Payload					(0x499602D2, 0x499602D2) = [1234567890, 1234567890]
+				7.	DATASTREAM_END_CHAR 	(0x04)
+
+			- Expected output
+				-  SerialManagerBase: RespondToByte: Start data stream.
+                - SerialManagerBase: RespondToByte: Stream length = 13
+                - SerialManagerBase: RespondToByte: Time to process stream!
+            	- Stream is of type 'test'.
+                - int is 1234567890
+                - float is 1228890.25
+
+			To register a callback when a datastream message is received, use setDataStreamCallback() and set a unique message type (i.e. not 'gha', 'dsl', afc', or 'test'):
+ 			- `serialManager.setDataStreamCallback(&dataStreamCallback);`
+			- `void dataStreamCallback(char* payload_p, String *msgType_p, int numBytes)`
+
+	License: MIT License.  Use at your own risk.  Have fun!
 */
 
 
@@ -98,6 +128,9 @@ class SerialManager_UI;  //forward declare.  Assume SerialManager_UI.h will be i
 #define QUADCHAR_CHAR__USE_PERSISTENT_MODE ((char)'_')  //this is an underscore
 
 #define SERIALMANAGERBASE_MAX_UI_ELEMENTS 30
+
+typedef void(*callback_t)(char* payload_p, String* msgType_p, int numBytes);	//typedef for datastream callback pointer 
+
 class SerialManagerBase {
   public:
     SerialManagerBase(void) {};
@@ -118,6 +151,8 @@ class SerialManagerBase {
 	  SINGLE_CHAR,	  STREAM_LENGTH,	  STREAM_DATA,	  QUAD_CHAR_1,	  QUAD_CHAR_2,	  QUAD_CHAR_3
 	};
 	
+	void setDataStreamCallback(callback_t callBackFunc_p);
+
 	SerialManager_UI* add_UI_element(SerialManager_UI *);
 
   protected:
@@ -135,7 +170,8 @@ class SerialManagerBase {
     char GUI_persistent_mode = 'g';  //is this used?  I don't think so.
     String TX_string;
     char mode_char, chan_char, data_char; //for quad_char processing
-	
+	callback_t _datastreamCallback_p = NULL;
+
 	std::vector<SerialManager_UI *> UI_element_ptr;
 };
 


### PR DESCRIPTION
Added callback for multibyte serial messages.  Tested using Realterm to send:
- 'test' message:   0x02 0x0D 0x00 0x00 0x00 0x03 0x74 0x65 0x73 0x74 0x03 0xD2 0x02 0x96 0x49 0xD2 0x02 0x96 0x49 0x04
- 'abcd' message: 0x02 0x0D 0x00 0x00 0x00 0x03 0x61 0x62 0x63 0x64 0x03 0xD2 0x02 0x96 0x49 0xD2 0x02 0x96 0x49 0x04

See attached script that modified an SD Card Writer example to register a callback function
[DataStream_example.zip](https://github.com/Tympan/Tympan_Library/files/8902012/DataStream_example.zip)

<img src="https://user-images.githubusercontent.com/42774675/173637859-efa7c76e-124d-42c7-aac2-7ffa7d5b59e2.png" height=150/>

Here is background info copied from SerialManagerBase.h

```
DataStreams: Besides the single-character and four-character modes, there are also
		     data streaming modes to support specialized communication.  These special modes
			 are not inteded to be invoked by a user's GUI, so they can be ignored.  To avoid
			 inadvertently invoking these modes, never send characters such as 0x02, 0x03, 0x04.
			 In fact, you should generally avoid any non-printable character or you risk seeing
			 unexpected behavior.

			 Datastreams expect the following message protocol.  Note that the message length and payload are sent as little endian (LSB, MSB):
			 	1.	DATASTREAM_START_CHAR 	(0x02)
				2.	Message Length (int32): number of bytes including parts-4 thru part-6
				3.	DATASTREAM_SEPARATOR 	(0x03)
				4.	Message Type (char): Avoid using the special characters 0x03 or 0x04.  (if set to ‘test’, it will print out the payload as an int, then a float)
				5.	DATASTREAM_SEPARATOR 	(0x03)
				6.	Payload
				7.	DATASTREAM_END_CHAR 	(0x04)

			Use RealTerm to send a 'test' message: 
			0x02 0x0D 0x00 0x00 0x00 0x03 0x74 0x65 0x73 0x74 0x03 0xD2 0x02 0x96 0x49 0xD2 0x02 0x96 0x49 0x04
				1. DATASTREAM_START_CHAR 	(0x02)
				2.	Message Length (int32): (0x000D) = 13 
				3.	DATASTREAM_SEPARATOR 	(0x03)
				4.	Message Type (char): 	(0x74657374) = 'test'
				5.	DATASTREAM_SEPARATOR 	(0x03)
				6.	Payload					(0x499602D2, 0x499602D2) = [1234567890, 1234567890]
				7.	DATASTREAM_END_CHAR 	(0x04)

			- Expected output
				-  SerialManagerBase: RespondToByte: Start data stream.
                - SerialManagerBase: RespondToByte: Stream length = 13
                - SerialManagerBase: RespondToByte: Time to process stream!
            	- Stream is of type 'test'.
                - int is 1234567890
                - float is 1228890.25

			To register a callback when a datastream message is received, use setDataStreamCallback() and set a unique message type (i.e. not 'gha', 'dsl', afc', or 'test'):
 			- `serialManager.setDataStreamCallback(&dataStreamCallback);`
			- `void dataStreamCallback(char* payload_p, String *msgType_p, int numBytes)`
```