### PR TITLE
Tympan_Library/issues/77 various minor fixes to examples

### DIFF
--- a/examples/02-Utility/DetectExtMic/DetectExtMic.ino
+++ b/examples/02-Utility/DetectExtMic/DetectExtMic.ino
@@ -18,7 +18,7 @@
 #include <Tympan_Library.h>  //include the Tympan Library
 
 //create audio library objects for handling the audio
-Tympan                    myTympan(TympanRev::F, audio_settings);   //do TympanRev::D or E or F
+Tympan                    myTympan(TympanRev::F);   //do TympanRev::D or E or F
 AudioInputI2S_F32         i2s_in;        //Digital audio *from* the Tympan AIC.
 AudioEffectGain_F32       gain1, gain2;  //Applies digital gain to audio data.
 AudioOutputI2S_F32        i2s_out;       //Digital audio *to* the Tympan AIC.  Always list last to minimize latency

--- a/examples/02-Utility/SoundLevelMeter/SoundLevelMeter.ino
+++ b/examples/02-Utility/SoundLevelMeter/SoundLevelMeter.ino
@@ -23,7 +23,8 @@ const int audio_block_samples = 128;     //do not make bigger than AUDIO_BLOCK_S
 AudioSettings_F32 audio_settings(sample_rate_Hz, audio_block_samples);
 
 //create audio library objects for handling the audio
-Tympan                        myTympan(TympanRev::F, audio_settings);   //do TympanRev::D or E or FAudioInputI2S_F32               i2s_in(audio_settings);       //Digital audio in *from* the Teensy Audio Board ADC.
+Tympan                        myTympan(TympanRev::F, audio_settings);   //do TympanRev::D or E or F
+AudioInputI2S_F32             i2s_in(audio_settings);       //Digital audio in *from* the Teensy Audio Board ADC.
 AudioFilterFreqWeighting_F32  freqWeight1(audio_settings);  //A-weighting filter (optionally C-weighting)
 AudioCalcLevel_F32            calcLevel1(audio_settings);   //use this to square the signal
 AudioOutputI2S_F32            i2s_out(audio_settings);      //Digital audio out *to* the Teensy Audio Board DAC.

--- a/examples/03-Intermediate/WDRC_SingleBand/WDRC_SingleBand.ino
+++ b/examples/03-Intermediate/WDRC_SingleBand/WDRC_SingleBand.ino
@@ -20,7 +20,7 @@
 
 
 //create audio library objects for handling the audio
-Tympan                  myTympan(TympanRev::F, audio_settings);   //do TympanRev::D or E or F
+Tympan                  myTympan(TympanRev::F);   //do TympanRev::D or E or F
 AudioInputI2S_F32       i2s_in;
 AudioFilterBiquad_F32   iir1; 
 AudioEffectCompWDRC_F32  compWDRC1;   

--- a/examples/04-FrequencyDomain/FormantShifter_FD/FormantShifter_FD.ino
+++ b/examples/04-FrequencyDomain/FormantShifter_FD/FormantShifter_FD.ino
@@ -46,8 +46,8 @@ AudioConnection_F32       patchCord4(gain1, 0, i2s_out, 1);         //connect to
 //control display and serial interaction
 bool enable_printCPUandMemory = false;
 void togglePrintMemoryAndCPU(void) { enable_printCPUandMemory = !enable_printCPUandMemory; };
-SerialManager serialManager(audioHardware);
-#define mySerial audioHardware   //audioHardware is a printable stream!
+SerialManager serialManager(myTympan);
+#define mySerial myTympan   //myTympan is a printable stream!
 
 //inputs and levels
 float input_gain_dB = 20.0f; //gain on the microphone
@@ -55,23 +55,23 @@ float formant_shift_gain_correction_dB = 0.0;  //will be used to adjust for gain
 float vol_knob_gain_dB = 0.0;      //will be overridden by volume knob
 void switchToPCBMics(void) {
   mySerial.println("Switching to PCB Mics.");
-  audioHardware.inputSelect(TYMPAN_INPUT_ON_BOARD_MIC); // use the microphone jack - defaults to mic bias OFF
-  audioHardware.setInputGain_dB(input_gain_dB);
+  myTympan.inputSelect(TYMPAN_INPUT_ON_BOARD_MIC); // use the microphone jack - defaults to mic bias OFF
+  myTympan.setInputGain_dB(input_gain_dB);
 }
 void switchToLineInOnMicJack(void) {
   mySerial.println("Switching to Line-in on Mic Jack.");
-  audioHardware.inputSelect(TYMPAN_INPUT_JACK_AS_LINEIN); // use the microphone jack - defaults to mic bias OFF  
-  audioHardware.setInputGain_dB(0.0);
+  myTympan.inputSelect(TYMPAN_INPUT_JACK_AS_LINEIN); // use the microphone jack - defaults to mic bias OFF  
+  myTympan.setInputGain_dB(0.0);
 }
 void switchToMicInOnMicJack(void) {
   mySerial.println("Switching to Mic-In on Mic Jack.");
-  audioHardware.inputSelect(TYMPAN_INPUT_JACK_AS_MIC); // use the microphone jack - defaults to mic bias OFF   
-  audioHardware.setInputGain_dB(input_gain_dB);
+  myTympan.inputSelect(TYMPAN_INPUT_JACK_AS_MIC); // use the microphone jack - defaults to mic bias OFF   
+  myTympan.setInputGain_dB(input_gain_dB);
 }
       
 // define the setup() function, the function that is called once when the device is booting
 void setup() {
-  audioHardware.beginBothSerial(); delay(1000);
+  myTympan.beginBothSerial(); delay(1000);
   mySerial.println("FormantShifter: starting setup()...");
   mySerial.print("    : sample rate (Hz) = ");  mySerial.println(audio_settings.sample_rate_Hz);
   mySerial.print("    : block size (samples) = ");  mySerial.println(audio_settings.audio_block_samples);
@@ -92,11 +92,11 @@ void setup() {
   }
 
   //Enable the Tympan to start the audio flowing!
-  audioHardware.enable(); // activate AIC
+  myTympan.enable(); // activate AIC
 
   //setup DC-blocking highpass filter running in the ADC hardware itself
   float cutoff_Hz = 60.0;  //set the default cutoff frequency for the highpass filter
-  audioHardware.setHPFonADC(true,cutoff_Hz,audio_settings.sample_rate_Hz); //set to false to disble
+  myTympan.setHPFonADC(true,cutoff_Hz,audio_settings.sample_rate_Hz); //set to false to disble
 
   //Choose the desired input
   switchToPCBMics();        //use PCB mics as input
@@ -104,7 +104,7 @@ void setup() {
   //switchToLineInOnMicJack();  //use Mic jack as line input (ie, no mic bias)
   
   //Set the desired volume levels
-  audioHardware.volume_dB(0);                   // headphone amplifier.  -63.6 to +24 dB in 0.5dB steps.
+  myTympan.volume_dB(0);                   // headphone amplifier.  -63.6 to +24 dB in 0.5dB steps.
    
   // configure the blue potentiometer
   servicePotentiometer(millis(),0); //update based on the knob setting the "0" is not relevant here.
@@ -144,7 +144,7 @@ void servicePotentiometer(unsigned long curTime_millis, const unsigned long upda
   if ((curTime_millis - lastUpdate_millis) > updatePeriod_millis) { //is it time to update the user interface?
 
     //read potentiometer
-    float val = float(audioHardware.readPotentiometer()) / 1023.0; //0.0 to 1.0
+    float val = float(myTympan.readPotentiometer()) / 1023.0; //0.0 to 1.0
     val = (1.0/9.0) * (float)((int)(9.0 * val + 0.5)); //quantize so that it doesn't chatter...0 to 1.0
 
     //use the potentiometer value to control something interesting

--- a/examples/04-FrequencyDomain/FrequencyShifter_FD/FrequencyShifter_FD.ino
+++ b/examples/04-FrequencyDomain/FrequencyShifter_FD/FrequencyShifter_FD.ino
@@ -56,32 +56,32 @@ AudioConnection_F32       patchCord40(gain1, 0, i2s_out, 1);       //connect to 
 //control display and serial interaction
 bool enable_printCPUandMemory = false;
 void togglePrintMemoryAndCPU(void) { enable_printCPUandMemory = !enable_printCPUandMemory; };
-SerialManager serialManager(audioHardware);
-#define mySerial audioHardware   //audioHardware is a printable stream!
+SerialManager serialManager(myTympan);
+#define mySerial myTympan   //myTympan is a printable stream!
 
 //inputs and levels
 float input_gain_dB = 15.0f; //gain on the microphone
 float vol_knob_gain_dB = 0.0;      //will be overridden by volume knob
 void switchToPCBMics(void) {
   mySerial.println("Switching to PCB Mics.");
-  audioHardware.inputSelect(TYMPAN_INPUT_ON_BOARD_MIC); // use the microphone jack - defaults to mic bias OFF
-  audioHardware.setInputGain_dB(input_gain_dB);
+  myTympan.inputSelect(TYMPAN_INPUT_ON_BOARD_MIC); // use the microphone jack - defaults to mic bias OFF
+  myTympan.setInputGain_dB(input_gain_dB);
 }
 void switchToLineInOnMicJack(void) {
   mySerial.println("Switching to Line-in on Mic Jack.");
-  audioHardware.inputSelect(TYMPAN_INPUT_JACK_AS_LINEIN); // use the microphone jack - defaults to mic bias OFF  
-  audioHardware.setInputGain_dB(0.0);
+  myTympan.inputSelect(TYMPAN_INPUT_JACK_AS_LINEIN); // use the microphone jack - defaults to mic bias OFF  
+  myTympan.setInputGain_dB(0.0);
 }
 void switchToMicInOnMicJack(void) {
   mySerial.println("Switching to Mic-In on Mic Jack.");
-  audioHardware.inputSelect(TYMPAN_INPUT_JACK_AS_MIC); // use the microphone jack - defaults to mic bias OFF   
-  audioHardware.setEnableStereoExtMicBias(true);  //put the mic bias on both channels
-  audioHardware.setInputGain_dB(input_gain_dB);
+  myTympan.inputSelect(TYMPAN_INPUT_JACK_AS_MIC); // use the microphone jack - defaults to mic bias OFF   
+  myTympan.setEnableStereoExtMicBias(true);  //put the mic bias on both channels
+  myTympan.setInputGain_dB(input_gain_dB);
 }
       
 // define the setup() function, the function that is called once when the device is booting
 void setup() {
-  audioHardware.beginBothSerial(); delay(1000);
+  myTympan.beginBothSerial(); delay(1000);
   mySerial.println("freqShifter: starting setup()...");
   mySerial.print("    : sample rate (Hz) = ");  mySerial.println(audio_settings.sample_rate_Hz);
   mySerial.print("    : block size (samples) = ");  mySerial.println(audio_settings.audio_block_samples);
@@ -105,11 +105,11 @@ void setup() {
   freqShift.setShift_bins(shift_bins); //0 is no ffreq shifting.
  
   //Enable the Tympan to start the audio flowing!
-  audioHardware.enable(); // activate AIC
+  myTympan.enable(); // activate AIC
 
   //setup DC-blocking highpass filter running in the ADC hardware itself
   float cutoff_Hz = 60.0;  //set the default cutoff frequency for the highpass filter
-  audioHardware.setHPFonADC(true,cutoff_Hz,audio_settings.sample_rate_Hz); //set to false to disble
+  myTympan.setHPFonADC(true,cutoff_Hz,audio_settings.sample_rate_Hz); //set to false to disble
 
   //Choose the desired input
   switchToPCBMics();        //use PCB mics as input
@@ -117,7 +117,7 @@ void setup() {
   //switchToLineInOnMicJack();  //use Mic jack as line input (ie, no mic bias)
   
   //Set the desired volume levels
-  audioHardware.volume_dB(0);                   // headphone amplifier.  -63.6 to +24 dB in 0.5dB steps.
+  myTympan.volume_dB(0);                   // headphone amplifier.  -63.6 to +24 dB in 0.5dB steps.
    
   // configure the blue potentiometer
   servicePotentiometer(millis(),0); //update based on the knob setting the "0" is not relevant here.
@@ -157,7 +157,7 @@ void servicePotentiometer(unsigned long curTime_millis, const unsigned long upda
   if ((curTime_millis - lastUpdate_millis) > updatePeriod_millis) { //is it time to update the user interface?
 
     //read potentiometer
-    float val = float(audioHardware.readPotentiometer()) / 1023.0; //0.0 to 1.0
+    float val = float(myTympan.readPotentiometer()) / 1023.0; //0.0 to 1.0
     val = (1.0/9.0) * (float)((int)(9.0 * val + 0.5)); //quantize so that it doesn't chatter...0 to 1.0
 
     //use the potentiometer value to control something interesting
@@ -166,8 +166,8 @@ void servicePotentiometer(unsigned long curTime_millis, const unsigned long upda
 
       //change the volume
       float vol_dB = 0.f + 30.0f * ((val - 0.5) * 2.0); //set volume as 0dB +/- 30 dB
-      audioHardware.print("Changing output volume to = "); audioHardware.print(vol_dB); audioHardware.println(" dB");
-      audioHardware.volume_dB(vol_dB);
+      myTympan.print("Changing output volume to = "); myTympan.print(vol_dB); myTympan.println(" dB");
+      myTympan.volume_dB(vol_dB);
 
     }
 

--- a/examples/04-FrequencyDomain/LowpassFilter_FD/AudioEffectLowpass_FD_F32.h
+++ b/examples/04-FrequencyDomain/LowpassFilter_FD/AudioEffectLowpass_FD_F32.h
@@ -96,8 +96,9 @@ void AudioEffectLowpass_FD_F32::update(void)
   // ///////////// End do your processing here
 
   //call the IFFT
-  audio_block_f32_t *out_audio_block = myIFFT.execute(complex_2N_buffer); //out_block is pre-allocated in here.
- 
+  audio_block_f32_t *out_audio_block = NULL;
+  myIFFT.execute(complex_2N_buffer, out_audio_block); //out_block is pre-allocated in here.
+
   //send the returned audio block.  Don't issue the release command here because myIFFT will re-use it
   AudioStream_F32::transmit(out_audio_block); //don't release this buffer because myIFFT re-uses it within its own code
   return;

--- a/examples/04-FrequencyDomain/PitchShifter_FD/PitchShifter_FD.ino
+++ b/examples/04-FrequencyDomain/PitchShifter_FD/PitchShifter_FD.ino
@@ -111,19 +111,19 @@ float input_gain_dB = 15.0f; //gain on the microphone
 float vol_knob_gain_dB = 0.0;      //will be overridden by volume knob
 void switchToPCBMics(void) {
   Serial.println("Switching to PCB Mics.");
-  audioHardware.inputSelect(TYMPAN_INPUT_ON_BOARD_MIC); // use the microphone jack - defaults to mic bias OFF
-  audioHardware.setInputGain_dB(input_gain_dB);
+  myTympan.inputSelect(TYMPAN_INPUT_ON_BOARD_MIC); // use the microphone jack - defaults to mic bias OFF
+  myTympan.setInputGain_dB(input_gain_dB);
 }
 void switchToLineInOnMicJack(void) {
   Serial.println("Switching to Line-in on Mic Jack.");
-  audioHardware.inputSelect(TYMPAN_INPUT_JACK_AS_LINEIN); // use the microphone jack - defaults to mic bias OFF  
-  audioHardware.setInputGain_dB(0.0);
+  myTympan.inputSelect(TYMPAN_INPUT_JACK_AS_LINEIN); // use the microphone jack - defaults to mic bias OFF  
+  myTympan.setInputGain_dB(0.0);
 }
 void switchToMicInOnMicJack(void) {
   Serial.println("Switching to Mic-In on Mic Jack.");
-  audioHardware.inputSelect(TYMPAN_INPUT_JACK_AS_MIC); // use the microphone jack - defaults to mic bias OFF   
-  audioHardware.setEnableStereoExtMicBias(true);  //put the mic bias on both channels
-  audioHardware.setInputGain_dB(input_gain_dB);
+  myTympan.inputSelect(TYMPAN_INPUT_JACK_AS_MIC); // use the microphone jack - defaults to mic bias OFF   
+  myTympan.setEnableStereoExtMicBias(true);  //put the mic bias on both channels
+  myTympan.setInputGain_dB(input_gain_dB);
 }
 
 
@@ -131,7 +131,7 @@ void switchToMicInOnMicJack(void) {
       
 // define the setup() function, the function that is called once when the device is booting
 void setup() {
-  //audioHardware.beginBothSerial(); 
+  //myTympan.beginBothSerial(); 
   delay(500);
   Serial.println("pitchShifter: starting setup()...");
   Serial.print("    : sample rate (Hz) = ");  Serial.println(audio_settings.sample_rate_Hz);
@@ -154,11 +154,11 @@ void setup() {
   pitchShift.setScaleFac(scale_fac); //1.0 is no pitch shifting.
  
   //Enable the Tympan to start the audio flowing!
-  audioHardware.enable(); // activate AIC
+  myTympan.enable(); // activate AIC
 
   //setup DC-blocking highpass filter running in the ADC hardware itself
   float cutoff_Hz = 60.0;  //set the default cutoff frequency for the highpass filter
-  audioHardware.setHPFonADC(true,cutoff_Hz,audio_settings.sample_rate_Hz); //set to false to disble
+  myTympan.setHPFonADC(true,cutoff_Hz,audio_settings.sample_rate_Hz); //set to false to disble
 
   //Choose the desired input
   switchToPCBMics();        //use PCB mics as input
@@ -166,7 +166,7 @@ void setup() {
   //switchToLineInOnMicJack();  //use Mic jack as line input (ie, no mic bias)
   
   //Set the desired volume levels
-  audioHardware.volume_dB(0);                   // headphone amplifier.  -63.6 to +24 dB in 0.5dB steps.
+  myTympan.volume_dB(0);                   // headphone amplifier.  -63.6 to +24 dB in 0.5dB steps.
    
   // configure the blue potentiometer
   servicePotentiometer(millis(),0); //update based on the knob setting the "0" is not relevant here.
@@ -211,7 +211,7 @@ void servicePotentiometer(unsigned long curTime_millis, const unsigned long upda
   if ((curTime_millis - lastUpdate_millis) > updatePeriod_millis) { //is it time to update the user interface?
 
     //read potentiometer
-    float val = float(audioHardware.readPotentiometer()) / 1023.0; //0.0 to 1.0
+    float val = float(myTympan.readPotentiometer()) / 1023.0; //0.0 to 1.0
     val = (1.0/9.0) * (float)((int)(9.0 * val + 0.5)); //quantize so that it doesn't chatter...0 to 1.0
 
     //use the potentiometer value to control something interesting
@@ -220,8 +220,8 @@ void servicePotentiometer(unsigned long curTime_millis, const unsigned long upda
 
       //change the volume
       float vol_dB = 0.f + 30.0f * ((val - 0.5) * 2.0); //set volume as 0dB +/- 30 dB
-      audioHardware.print("Changing output volume to = "); audioHardware.print(vol_dB); audioHardware.println(" dB");
-      audioHardware.volume_dB(vol_dB);
+      myTympan.print("Changing output volume to = "); myTympan.print(vol_dB); myTympan.println(" dB");
+      myTympan.volume_dB(vol_dB);
     }
     
     lastUpdate_millis = curTime_millis;

--- a/examples/05-FullSystems/WDRC_8BandFIR_Stereo_wApp/WDRC_8BandFIR_Stereo_wApp.ino
+++ b/examples/05-FullSystems/WDRC_8BandFIR_Stereo_wApp/WDRC_8BandFIR_Stereo_wApp.ino
@@ -63,6 +63,7 @@ Tympan   myTympan(TympanRev::F, audio_settings);   //do TympanRev::D or E or F
 #include      "SerialManager.h"
 #include      "State.h"                     //must be after N_CHAN is defined
 BLE_UI&       ble = myTympan.getBLE_UI();   //myTympan owns the ble object, but we have a reference to it hereSerialManager serialManager(&ble);                 //create the serial manager for real-time control (via USB or App)
+SerialManager serialManager(&ble);         //create the serial manager for real-time control (via USB or App)
 State         myState(&audio_settings, &myTympan, &serialManager); //keeping one's state is useful for the App's GUI
 
 


### PR DESCRIPTION
Compile fix
   ./02-Utility/DetectExtMic/DetectExtMic.ino
    // Use simplest Tympan constructor .. no audio_settings need changed

Compile fix
   ./02-Utility/SoundLevelMeter/SoundLevelMeter.ino
    // carriage return was missing (lines combined)
    AFTER
      Tympan                        myTympan(TympanRev::F, audio_settings);   //do TympanRev::D or E or F
      AudioInputI2S_F32               i2s_in(audio_settings);       //Digital audio in *from* the Teensy Audio Board ADC.

Compile fix
   ./03-Intermediate/WDRC_SingleBand/WDRC_SingleBand.ino
    // Use simplest Tympan constructor .. no audio_settings need changed

Compile fix
   ./04-FrequencyDomain/FormantShifter_FD/FormantShifter_FD.ino         
   // constructor for SerialManaget expects a Tympan reference
     replace  audioHardware  with myTympan throughout the .ino
               
Compile fix
   ./04-FrequencyDomain/PitchShifter_FD/PitchShifter_FD.ino       
   // constructor for SerialManaget expects a Tympan reference
     replace  audioHardware  with myTympan throughout the .ino

Compile fix
   ./04-FrequencyDomain/FrequencyShifter_FD/FrequencyShifter_FD.ino             nope
            FrequencyShifter_FD:59: error: 'audioHardware' was not declared in this scope
            59 | SerialManager serialManager(audioHardware);
               |                             ^~~~~~~~~~~~~

   constructor for SerialManaget expects a Tympan reference
     relace  audioHardware  with myTympan throughout the .ino


Compile fix
   ./04-FrequencyDomain/LowpassFilter_FD/LowpassFilter_FD.ino     
    // split the execute so it follows the IFFT pattern
    AFTER:
      //call the IFFT
  audio_block_f32_t *out_audio_block = NULL;
  myIFFT.execute(complex_2N_buffer, out_audio_block); //out_block is pre-allocated in here.

Compile fix
   ./05-FullSystems/WDRC_8BandFIR_Stereo_wApp/WDRC_8BandFIR_Stereo_wApp.ino  
  // copy over the serialManager initialisation
  AFTER:
  SerialManager serialManager(&ble);         //create the serial manager for real-time control (via USB or App)
  State         myState(&audio_settings, &myTympan, &serialManager); //keeping one's state is useful for the App's GUI

    
    