### PR TITLE
Add BLE::sendString() method to enable alternative message protocols.

### DIFF
--- a/src/BLE/ble.h
+++ b/src/BLE/ble.h
@@ -12,6 +12,7 @@ public:
 	//virtual int begin(int doFactoryReset) = 0; 
 	virtual void setupBLE(int) = 0;            //to be called from the Arduino sketch's setup() routine.  Includes factory reset.
   virtual void setupBLE(int, bool) = 0;            //to be called from the Arduino sketch's setup() routine.  Includes factory reset.
+  virtual size_t sendString(const String &s, bool print_debug) = 0;  // Send string as raw bytes
   virtual size_t sendMessage(const String &s) = 0;
 	//virtual size_t recvMessage(String *s) = 0;
 	virtual size_t recvBLE(String *s)=0;


### PR DESCRIPTION
This change allows BLE::sendString() to be used with BLE references. BLE_nRF52::sendString() and BLE_BC127::sendString() both already exist with this same signature.