### PR TITLE
Feature/32bit quad i2s: Begin making switchable 16/32 which fixes RevD

### DIFF
--- a/src/output_i2s_quad_F32.h
+++ b/src/output_i2s_quad_F32.h
@@ -87,8 +87,7 @@ protected:
 	static void isr(void);
 	static void isr_shuffleDataBlocks(audio_block_f32_t *&, audio_block_f32_t *&, uint32_t &);
 	void update_1chan(const int, audio_block_f32_t *&, audio_block_f32_t *&, uint32_t &);
-	bool transferUsing32bit = true;  //I2S transfers using 32 bit values (instead of 16-bit).  Only used for Teensy4.1 or later
-	uint32_t i2s_buffer_to_use_bytes;
+	static bool transferUsing32bit;  //I2S transfers using 32 bit values (instead of 16-bit).  See instantiation in the cpp file  for the default and see begin() and config_i2s() for changes
 private:
 	static audio_block_f32_t *block_ch1_2nd;
 	static audio_block_f32_t *block_ch2_2nd;

--- a/src/output_i2s_quad_F32.h
+++ b/src/output_i2s_quad_F32.h
@@ -87,6 +87,8 @@ protected:
 	static void isr(void);
 	static void isr_shuffleDataBlocks(audio_block_f32_t *&, audio_block_f32_t *&, uint32_t &);
 	void update_1chan(const int, audio_block_f32_t *&, audio_block_f32_t *&, uint32_t &);
+	bool transferUsing32bit = true;  //I2S transfers using 32 bit values (instead of 16-bit).  Only used for Teensy4.1 or later
+	uint32_t i2s_buffer_to_use_bytes;
 private:
 	static audio_block_f32_t *block_ch1_2nd;
 	static audio_block_f32_t *block_ch2_2nd;


### PR DESCRIPTION
While the long-term plan is to make all of the I2S classes be 32-bits, I don't think that anyone is planning on digging into the I2S and DMA settings for the older Tympan RevD.  Because I don't yet want to abandon RevD, we need to continue to support 16-bit transfers for RevD.

For the Quad classes, I've altered the classes so that they know whether they were configured for 32 bit (Rev E/F) or 16 bit (Rev D).  The isr() and update() methods then work correctly based on the given data size.

I've tested these changes using the attached version of the ChangeSampleRate example.  on a RevD and on a RevE.  I've tested Quad and Stereo.  I've tested 44kHz and 96kHz.  They all seemed to work fine for me.

If these changes look safe and compatible with your other work, please accept the pull request so that they merge into the develop branch.

[ChangeSampleRate_Quad.zip](https://github.com/user-attachments/files/21603452/ChangeSampleRate_Quad.zip)
