### PR TITLE
AudioSDPlayer_F32: Added parser for playing WAV files in the Extensible format

### DIFF
--- a/src/AudioSDPlayer_F32.h
+++ b/src/AudioSDPlayer_F32.h
@@ -147,6 +147,7 @@ class AudioSDPlayer_F32 : public AudioStream_F32
 		const Wave_Format_e& getWavFormatType(void);
 		const Fmt_Pcm_s& getFmtPcmHeader(void);
 		const Fmt_Ieee_s& getFmtIeeeHeader(void);
+		const Fmt_Ext_s& getFmtExtHeader(void);
 		const Fact_s& getFactHeader(void);
 		const std::vector<Info_Tags> getInfoTagIds(void);
 		const std::string getInfoTag(const Info_Tags tagId);
@@ -173,6 +174,7 @@ class AudioSDPlayer_F32 : public AudioStream_F32
 		Riff_Header_u riffChunk;
 		Fmt_Pcm_Header_u fmtPcmChunk;
 		Fmt_Ieee_Header_u fmtIeeeChunk;
+		Fmt_Ext_Header_u fmtExtChunk;
 		Fact_Header_u factChunk;
 		List_Header_u listChunk;
 		Data_Header_u dataChunk;
@@ -222,6 +224,7 @@ class AudioSDPlayer_F32 : public AudioStream_F32
 		Wav_Header_Err parseRiffChunk(SdFile &file, Riff_Header_u &riff);
 		Wav_Header_Err parseFmtPcmChunk(SdFile &file, Fmt_Pcm_Header_u &fmtPcmChunk);
 		Wav_Header_Err parseFmtIeeeChunk(SdFile &file, Fmt_Ieee_Header_u &fmtIeeeChunk);
+		Wav_Header_Err parseFmtExtChunk(SdFile &file, Fmt_Ext_Header_u &fmtExtChunk);
 		Wav_Header_Err parseFactChunk(SdFile &file, Fact_Header_u &factChunk);
 		Wav_Header_Err parseListChunk(SdFile &file, List_Header_u &listChunk, InfoKeyVal_t &infoTagStr, bool checkTagIDFlag);
 


### PR DESCRIPTION
In addition to "PCM" and IEEE" format, WAV files exist as "Extensible" format, which provides an extended header to specify fields such as multi speaker masking.  WAV editors such as FFMPEG choose EXTENSIBLE format when the sample rate > 48kHz, # of channels > 2, or bits per sample > 16-bit.  This feature allows Extensible WAV files to be played (but not recorded).  

Note that there is ambiguity whether Extensible format WAV files require a "FACT" chunk.  As FFMPEG does not include a FACT chunk for EXTENSIBLE format when the audio is PCM, I've made the FACT chunk optional when paying files.  I also made it optional for IEEE format.

This what tested with the attached Extensible WAV file:
[MRT_EM_trial34_96kHz.wav](https://github.com/user-attachments/files/22181281/MRT_EM_trial34_96kHz.wav)